### PR TITLE
Add 1.0.0 (JDK8 only)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,22 @@ env:
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-openjdk-8,latest"
-      TEMPLATE_VALUES="base_image=java:8-jre,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
+      TEMPLATE_VALUES="base_image=java:8-jre,nifi_version=0.7.0,distribution_url=http://mirrors.sonic.net/apache"
       DESTINATION="0.7.0-openjdk-8.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-openjdk-7"
-      TEMPLATE_VALUES="base_image=java:7-jre,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
+      TEMPLATE_VALUES="base_image=java:7-jre,nifi_version=0.7.0,distribution_url=http://mirrors.sonic.net/apache"
       DESTINATION="0.7.0-openjdk-7.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-oracle-java8"
-      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.8,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
+      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.8,nifi_version=0.7.0,distribution_url=http://mirrors.sonic.net/apache"
       DESTINATION="0.7.0-oracle-java8.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-oracle-java7"
-      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.7,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
+      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.7,nifi_version=0.7.0,distribution_url=http://mirrors.sonic.net/apache"
       DESTINATION="0.7.0-oracle-java7.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,16 @@ env:
   matrix:
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
+      DOCKER_TAGS="1.0.0-openjdk-8,latest"
+      TEMPLATE_VALUES="base_image=java:8-jre,nifi_version=1.0.0,distribution_url=http://apache.cs.utah.edu"
+      DESTINATION="1.0.0-openjdk-8.dockerfile"
+    - >-
+      TEMPLATE_FILE="templates/Dockerfile-template"
+      DOCKER_TAGS="1.0.0-oracle-java8"
+      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.8,nifi_version=1.0.0,distribution_url=http://apache.cs.utah.edu"
+      DESTINATION="1.0.0-oracle-java8.dockerfile"
+    - >-
+      TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-openjdk-8,latest"
       TEMPLATE_VALUES="base_image=java:8-jre,nifi_version=0.7.0,distribution_url=http://mirrors.sonic.net/apache"
       DESTINATION="0.7.0-openjdk-8.dockerfile"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ env:
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-openjdk-8,latest"
-      TEMPLATE_VALUES="base_image=java:8-jre,nifi_version=0.7.0,distribution_url=http://mirrors.sonic.net/apache"
+      TEMPLATE_VALUES="base_image=java:8-jre,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
       DESTINATION="0.7.0-openjdk-8.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-openjdk-7"
-      TEMPLATE_VALUES="base_image=java:7-jre,nifi_version=0.7.0,distribution_url=http://apache.claz.org"
+      TEMPLATE_VALUES="base_image=java:7-jre,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
       DESTINATION="0.7.0-openjdk-7.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
@@ -39,7 +39,7 @@ env:
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"
       DOCKER_TAGS="0.7.0-oracle-java7"
-      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.7,nifi_version=0.7.0,distribution_url=http://apache.mirrors.ionfish.org"
+      TEMPLATE_VALUES="base_image=airdock/oracle-jdk:jre-1.7,nifi_version=0.7.0,distribution_url=http://apache.cs.utah.edu"
       DESTINATION="0.7.0-oracle-java7.dockerfile"
     - >-
       TEMPLATE_FILE="templates/Dockerfile-template"

--- a/README.adoc
+++ b/README.adoc
@@ -41,6 +41,12 @@ The images are built by {uri-travis-ci}[Travis CI] and are available on {uri-doc
 | `mkobit/nifi:latest`
 | image:{uri-imagelayers-badge}:latest.svg[title="Image layers and size", alt="Image layers and size",link="{uri-imagelayers}?images=mkobit%2Fnifi:latest"]
 
+| `mkobit/nifi:1.0.0-openjdk-8`
+| image:{uri-imagelayers-badge}:1.0.0-openjdk-8.svg[title="Image layers and size", alt="Image layers and size",link="{uri-imagelayers}?images=mkobit%2Fnifi:1.0.0-openjdk-8"]
+
+| `mkobit/nifi:1.0.0-oracle-java8`
+| image:{uri-imagelayers-badge}:1.0.0-oracle-java8.svg[title="Image layers and size", alt="Image layers and size",link="{uri-imagelayers}?images=mkobit%2Fnifi:1.0.0-oracle-java8"]
+
 | `mkobit/nifi:0.7.0-openjdk-8`
 | image:{uri-imagelayers-badge}:0.7.0-openjdk-8.svg[title="Image layers and size", alt="Image layers and size",link="{uri-imagelayers}?images=mkobit%2Fnifi:0.7.0-openjdk-8"]
 


### PR DESCRIPTION
I've added a 1.0.0 tags, since this version is already quite stable and I think many people would like to play around with it or even start using it in production.

I'm not entirely sure which `distribution_url` to use, but apache.cs.utah.edu is definitely working for 1.0.0 and some of the others weren't.
